### PR TITLE
Remove ect and oxipng, and add zopflipng to image-keepalpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The default configuration uses the following tools:
 - [pingo](https://css-ig.net/pingo/) (for Windows. To run this on Linux and MacOS you would need to install `wine`)
 - [oxipng](https://github.com/shssoichiro/oxipng/)
 - [pngout](http://www.advsys.net/ken/utils.html)
+- [zopflipng](https://github.com/google/zopfli)
 - [pngquant](https://pngquant.org/)
 - [jpegoptim](https://github.com/tjko/jpegoptim/)
 - jpegtran (a JPEG manipulation tool provided by [libjpeg](https://jpegclub.org/reference/reference-sources/), [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo), or [mozjpeg](https://github.com/mozilla/mozjpeg/))

--- a/complete-config.yaml
+++ b/complete-config.yaml
@@ -66,7 +66,7 @@ presets:
     shorthands: [image-alpha, img-alpha]
     default-tools:
       image/vnd.mozilla.apng: []
-      image/png: [pingo]
+      image/png: [pingo, zopflipng]
       image/gif: []
 
   lossy-lowquality:

--- a/complete-config.yaml
+++ b/complete-config.yaml
@@ -65,8 +65,9 @@ presets:
     description: Lossless image compression with high effort compression settings and fully transparent pixels (a = 0) retained.
     shorthands: [image-alpha, img-alpha]
     default-tools:
-      image/vnd.mozilla.apng: [oxipng, pingo]
-      image/png: [oxipng, ect, pingo]
+      image/vnd.mozilla.apng: []
+      image/png: [pingo]
+      image/gif: []
 
   lossy-lowquality:
     # Images are typically compressed to at least 40 score in the SSIMULACRA2 metric
@@ -144,7 +145,8 @@ tools:
       lossless-loweffort: ["--mt-file", "--mt-deflate", "-2"] # ect does no compression at 1
       lossless-higheffort: ["--mt-file", "--mt-deflate", "-9"]
       lossless-maxbrute: ["--mt-file", "--mt-deflate", "-9", "--allfilters"]
-      image-keepalpha: ["--mt-file", "--mt-deflate", "-9", "--strict"]
+      # Omitted, still modifies fully transparent pixels
+      #image-keepalpha: ["--mt-file", "--mt-deflate", "-9", "--strict"]
       # lossy-* omitted: Lossless only
 
   imagemagick:
@@ -212,7 +214,8 @@ tools:
       lossless-loweffort: ["--force", "-o", "1", "-a"]
       lossless-higheffort: ["--force", "-o", "max", "-a"]
       lossless-maxbrute: ["--force", "-o", "max", "-a", "-Z", "--zi", "100"]
-      image-keepalpha: ["--force", "-o", "max"] # Opt-out of -a
+      # Omitted, still modifies fully transparent pixels
+      #image-keepalpha: ["--force", "-o", "max"] # Opt-out of -a
       # lossy-* omitted: Lossless only
 
   optipng:

--- a/internal/config/defaultconfig.go
+++ b/internal/config/defaultconfig.go
@@ -248,7 +248,7 @@ tools:
       # lossy-almostperfect omitted: Can't consistently reach 90 SSIM2 at max quality score
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
 
-  
+
   # JPEG
   # JPEG does not support transparent pixels, no image-keepalpha
   jpegoptim:

--- a/internal/config/defaultconfig.go
+++ b/internal/config/defaultconfig.go
@@ -65,7 +65,7 @@ presets:
     shorthands: [image-alpha, img-alpha]
     default-tools:
       image/vnd.mozilla.apng: []
-      image/png: [pingo]
+      image/png: [pingo, zopflipng]
       image/gif: []
 
   lossy-lowquality:
@@ -217,6 +217,20 @@ tools:
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # lossy-* omitted: Lossless only
 
+  zopflipng:
+    description: Lossless PNG optimizer. https://github.com/google/zopfli/
+    command: zopflipng
+    platform: [windows, darwin, linux]
+    supported-formats: [image/png]
+    output-mode: input-output
+    arguments:
+      default-args: ["--lossy_transparent"]
+      lossless-loweffort: ["--lossy_transparent", "-q"]
+      lossless-higheffort: ["--lossy_transparent", "-m"]
+      lossless-maxbrute: ["--lossy_transparent", "--iterations=100", "--filters=01234mepb"]
+      image-keepalpha: ["-m"]
+      # lossy-* omitted: Lossless only
+
   pngquant:
     description: Lossy PNG compressor. https://pngquant.org/
     command: pngquant
@@ -234,7 +248,7 @@ tools:
       # lossy-almostperfect omitted: Can't consistently reach 90 SSIM2 at max quality score
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
 
-
+  
   # JPEG
   # JPEG does not support transparent pixels, no image-keepalpha
   jpegoptim:

--- a/internal/config/defaultconfig.go
+++ b/internal/config/defaultconfig.go
@@ -64,8 +64,9 @@ presets:
     description: Lossless image compression with high effort compression settings and fully transparent pixels (a = 0) retained.
     shorthands: [image-alpha, img-alpha]
     default-tools:
-      image/vnd.mozilla.apng: [oxipng, pingo]
-      image/png: [oxipng, ect, pingo]
+      image/vnd.mozilla.apng: []
+      image/png: [pingo]
+      image/gif: []
 
   lossy-lowquality:
     # Images are typically compressed to at least 40 score in the SSIMULACRA2 metric
@@ -143,7 +144,8 @@ tools:
       lossless-loweffort: ["--mt-file", "--mt-deflate", "-2"] # ect does no compression at 1
       lossless-higheffort: ["--mt-file", "--mt-deflate", "-9"]
       lossless-maxbrute: ["--mt-file", "--mt-deflate", "-9", "--allfilters"]
-      image-keepalpha: ["--mt-file", "--mt-deflate", "-9", "--strict"]
+      # Omitted, still modifies fully transparent pixels
+      #image-keepalpha: ["--mt-file", "--mt-deflate", "-9", "--strict"]
       # lossy-* omitted: Lossless only
 
   imagemagick:
@@ -197,7 +199,8 @@ tools:
       lossless-loweffort: ["--force", "-o", "1", "-a"]
       lossless-higheffort: ["--force", "-o", "max", "-a"]
       lossless-maxbrute: ["--force", "-o", "max", "-a", "-Z", "--zi", "100"]
-      image-keepalpha: ["--force", "-o", "max"] # Opt-out of -a
+      # Omitted, still modifies fully transparent pixels
+      #image-keepalpha: ["--force", "-o", "max"] # Opt-out of -a
       # lossy-* omitted: Lossless only
 
   pngout:


### PR DESCRIPTION
I've found out that ect and oxipng's `image-keepalpha` arguments has issues, it doesn't preserve transparent pixels

Thus, unfortunately ect and oxipng had to be disabled from running in `image-keepalpha`. As a compromise, I've added zopflipng into the default config list to replace these tools

| Name  | Image 1 | Image 2 |
|--------|---------|---------|
|original|<img width="128" height="128" alt="Shapes4RoundedFilled" src="https://github.com/user-attachments/assets/ce33e295-e79a-4b8f-9752-4a8e4b7588a3" />|<img width="128" height="128" alt="ButtonPushblockReset" src="https://github.com/user-attachments/assets/4f2ebef6-7c35-472d-826f-d694bb34dd48" />|
|ect|<img width="128" height="128" alt="Shapes4RoundedFilled-ect" src="https://github.com/user-attachments/assets/c19a28dd-48d7-4e6b-ab67-7e5e5f5e4f36" />|<img width="128" height="128" alt="ButtonPushblockReset-ect" src="https://github.com/user-attachments/assets/ceb29a5b-460c-4bcc-adc7-a8e19d40dcd7" />|
|oxipng|<img width="128" height="128" alt="Shapes4RoundedFilled-oxipng" src="https://github.com/user-attachments/assets/dee627b0-932d-40b6-8a99-e23de38a1415" />|<img width="128" height="128" alt="ButtonPushblockReset-oxipng" src="https://github.com/user-attachments/assets/d12fb8a5-c91d-46cc-a081-0360ba74a4f9" />|
|pingo|<img width="128" height="128" alt="Shapes4RoundedFilled-pingo" src="https://github.com/user-attachments/assets/0390c3c0-2165-40d4-88cf-07cb25d3fcdb" />|<img width="128" height="128" alt="ButtonPushblockReset-pingo" src="https://github.com/user-attachments/assets/7c845995-61e0-4f97-924d-ff08e1de71b6" />|
|zopflipng|<img width="128" height="128" alt="Shapes4RoundedFilled-zopflipng" src="https://github.com/user-attachments/assets/48a458e7-9a24-4539-948e-a46d55619388" />|<img width="128" height="128" alt="ButtonPushblockReset-zopflipng" src="https://github.com/user-attachments/assets/4f7569e6-b295-456b-884f-275a308adad3" />|