### PR TITLE
Implement Preset Includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ compacty uses a `config.yaml` file that defines tools, presets, etc. On first ru
 
 You can see the default configuration at [defaultconfig.go](./internal/config/defaultconfig.go). A more complete configuration is available at [complete-config.yaml](./complete-config.yaml) that contains even more tools, ready to be copy-pasted.
 
+In each tool's argument list, you can include (or reuse) arguments from other presets (that are part of the same tool) by using the syntax `@preset-name`. For example:
+```
+pngout:
+    description: Lossless PNG compressor. http://www.advsys.net/ken/utils.html
+    command: pngout
+    platform: [windows, darwin, linux]
+    supported-formats: [image/png]
+    output-mode: input-output
+    arguments:
+      default-args: ["-force", "-y"]
+      lossless-loweffort: ["@default-args", "-s3"]
+      lossless-higheffort: ["@default-args", "-s1"]
+      lossless-maxbrute: ["@default-args", "-s0"]
+      ...
+```
+During runtime, `lossless-loweffort` will be resolved to `["-force", "-y", "-s3"]`, `lossless-higheffort` will be resolved to `["-force", "-y", "-s1"]`, and so on. This is pretty handy to deduplicate flags that are there for setup (for example: forcing the tools to overwrite files), but can also be used to mix-and-match arguments. Note that circular includes are not allowed.
+
 Your `config.yaml` will be validated on startup to check for inconsistencies and potential problems. See `Validate()` in [config.go](./internal/config/config.go) for all checks.
 
 ## licensing

--- a/cmd/compacty/operatedfiles.go
+++ b/cmd/compacty/operatedfiles.go
@@ -136,7 +136,7 @@ func (of *OperatedFiles) SetTools(cfg *config.Config, preset string, toolNames [
 			continue
 		}
 
-		executedTool, ok := compressor.ToolConfigToExecutedTool(tool, preset)
+		executedTool, ok := compressor.ToolConfigToExecutedTool(tool, preset, toolName)
 		if !ok {
 			continue
 		}

--- a/complete-config.yaml
+++ b/complete-config.yaml
@@ -1,7 +1,7 @@
 #
 # A comprehensive list of tested tool configurations for compacty
 # To use a tool from this list, copy its entire block (e.g., the 'guetzli:' block) and paste it into the 'tools:' section of your config.yaml file
-
+# Note: The tool configuration for these may require a preset named "_setup"
 default-preset: default-args
 
 mime-extensions:
@@ -33,6 +33,15 @@ presets:
       image/png: [oxipng, ect, pingo]
       image/jpeg: [jpegoptim, ect, pingo]
       image/gif: [gifsicle]
+
+  _setup:
+    description: Internal preset meant to host arguments that are for setup. Not meant to be used directly.
+    shorthands: []
+    default-tools:
+      image/vnd.mozilla.apng: []
+      image/png: []
+      image/jpeg: []
+      image/gif: []
 
   lossless-loweffort:
     description: Lossless compression with fast, low effort compression settings.
@@ -134,17 +143,18 @@ tools:
 
   # Image compression tools, multiple formats
   ect:
-    description: Lossless file optimizer. https://github.com/fhanau/Efficient-Compression-Tool/
+    description: Lossless file compressor. https://github.com/fhanau/Efficient-Compression-Tool/
     command: ect
     platform: [windows, darwin, linux]
     supported-formats: [image/png, image/jpeg]
     output-mode: batch-overwrite
     arguments:
-      default-args: []
+      _setup: ["--mt-file", "--mt-deflate"]
+      default-args: ["@_setup"]
       # Note: --mt-deflate speeds up processing considerably, but produces in a very slightly larger image (~0.1-0.2% more)
-      lossless-loweffort: ["--mt-file", "--mt-deflate", "-2"] # ect does no compression at 1
-      lossless-higheffort: ["--mt-file", "--mt-deflate", "-9"]
-      lossless-maxbrute: ["--mt-file", "--mt-deflate", "-9", "--allfilters"]
+      lossless-loweffort: ["@default-args", "-2"] # ect does no compression at 1
+      lossless-higheffort: ["@default-args", "-9"]
+      lossless-maxbrute: ["@default-args", "-9", "--allfilters"]
       # Omitted, still modifies fully transparent pixels
       #image-keepalpha: ["--mt-file", "--mt-deflate", "-9", "--strict"]
       # lossy-* omitted: Lossless only
@@ -156,19 +166,20 @@ tools:
     supported-formats: [image/png, image/jpeg]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["mogrify", "-define", "png:compression-level=9", "-quality", "90"]
+      _setup: ["mogrify"]
+      default-args: ["@_setup", "-define", "png:compression-level=9", "-quality", "90"]
       # Lossless compression is PNG only
-      lossless-loweffort: ["mogrify", "-define", "png:compression-level=5", "-quality", "100"]
-      lossless-higheffort: ["mogrify", "-define", "png:compression-level=9", "-quality", "100"]
-      lossless-maxbrute: ["mogrify", "-define", "png:compression-level=9", "-quality", "100"]
+      lossless-loweffort: ["@_setup", "-define", "png:compression-level=5", "-quality", "100"]
+      lossless-higheffort: ["@_setup", "-define", "png:compression-level=9", "-quality", "100"]
+      lossless-maxbrute: ["@_setup", "-define", "png:compression-level=9", "-quality", "100"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # Lossy compression is JPEG only
-      lossy-lowquality: ["mogrify", "-quality", "25"]
-      lossy-subparquality: ["mogrify", "-quality", "35"]
-      lossy-midquality: ["mogrify", "-quality", "50"]
-      lossy-finequality: ["mogrify", "-quality", "70"]
-      lossy-highquality: ["mogrify", "-quality", "85"]
-      lossy-almostperfect: ["mogrify", "-quality", "100"]
+      lossy-lowquality: ["@_setup", "-quality", "25"]
+      lossy-subparquality: ["@_setup", "-quality", "35"]
+      lossy-midquality: ["@_setup", "-quality", "50"]
+      lossy-finequality: ["@_setup", "-quality", "70"]
+      lossy-highquality: ["@_setup", "-quality", "85"]
+      lossy-almostperfect: ["@_setup", "-quality", "100"]
 
   pingo:
     description: Lossless and lossy image optimizer designed for web context. https://css-ig.net/pingo/
@@ -196,24 +207,26 @@ tools:
     supported-formats: [image/png]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--force", "-z2"]
-      lossless-loweffort: ["--force", "-z1"]
-      lossless-higheffort: ["--force", "-z4"]
-      lossless-maxbrute: ["--force", "-z4", "-i100"]
+      _setup: ["--force"]
+      default-args: ["@_setup", "-z2"]
+      lossless-loweffort: ["@_setup", "-z1"]
+      lossless-higheffort: ["@_setup", "-z4"]
+      lossless-maxbrute: ["@_setup", "-z4", "-i100"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # lossy-* omitted: Lossless only
 
   oxipng:
-    description: Lossless PNG optimizer. https://github.com/shssoichiro/oxipng/
+    description: Lossless PNG compressor. https://github.com/shssoichiro/oxipng/
     command: oxipng
     platform: [windows, darwin, linux]
     supported-formats: [image/png, image/vnd.mozilla.apng]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--force"]
-      lossless-loweffort: ["--force", "-o", "1", "-a"]
-      lossless-higheffort: ["--force", "-o", "max", "-a"]
-      lossless-maxbrute: ["--force", "-o", "max", "-a", "-Z", "--zi", "100"]
+      _setup: ["--force"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup", "-o", "1", "-a"]
+      lossless-higheffort: ["@_setup", "-o", "max", "-a"]
+      lossless-maxbrute: ["@_setup", "-o", "max", "-a", "-Z", "--zi", "100"]
       # Omitted, still modifies fully transparent pixels
       #image-keepalpha: ["--force", "-o", "max"] # Opt-out of -a
       # lossy-* omitted: Lossless only
@@ -225,10 +238,11 @@ tools:
     supported-formats: [image/png]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["-force", "-clobber"]
-      lossless-loweffort: ["-force", "-clobber", "-o1"]
-      lossless-higheffort: ["-force", "-clobber", "-o7"]
-      lossless-maxbrute: ["-force", "-clobber", "-o7", "-zm1-9"]
+      _setup: ["-force", "-clobber"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup", "-o1"]
+      lossless-higheffort: ["@_setup", "-o7"]
+      lossless-maxbrute: ["@_setup", "-o7", "-zm1-9"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
 
   pngcrush:
@@ -238,24 +252,26 @@ tools:
     supported-formats: [image/png]
     output-mode: input-output
     arguments:
-      default-args: ["-force"]
-      lossless-loweffort: ["-force", "-zmem", "1", "-speed"]
-      lossless-higheffort: ["-force"]
-      lossless-maxbrute: ["-force", "-brute", "-reduce"]
+      _setup: ["-force"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup", "-zmem", "1", "-speed"]
+      lossless-higheffort: ["@_setup"]
+      lossless-maxbrute: ["@_setup", "-brute", "-reduce"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # lossy-* omitted: Lossless only
 
   pngout:
-    description: Lossless PNG optimizer. http://www.advsys.net/ken/utils.html
+    description: Lossless PNG compressor. http://www.advsys.net/ken/utils.html
     command: pngout
     platform: [windows, darwin, linux]
     supported-formats: [image/png]
     output-mode: input-output
     arguments:
-      default-args: ["-force", "-y"]
-      lossless-loweffort: ["-force", "-y", "-s3"]
-      lossless-higheffort: ["-force", "-y", "-s1"]
-      lossless-maxbrute: ["-force", "-y", "-s0"]
+      _setup: ["-force", "-y"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup", "-s3"]
+      lossless-higheffort: ["@_setup", "-s1"]
+      lossless-maxbrute: ["@_setup", "-s0"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # lossy-* omitted: Lossless only
 
@@ -275,19 +291,20 @@ tools:
 
   # PNG Lossy
   pngquant:
-    description: Lossy PNG optimizer. https://pngquant.org/
+    description: Lossy PNG compressor. https://pngquant.org/
     command: pngquant
     platform: [windows, darwin, linux]
     supported-formats: [image/png]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--ext=.png", "--force"]
+      _setup: ["--ext=.png", "--force"]
+      default-args: ["@_setup"]
       # lossless-* omitted: Lossy only
-      lossy-lowquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-60"]
-      lossy-subparquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-70"]
-      lossy-midquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-80"]
-      lossy-finequality: ["--ext=.png", "--force", "--speed=1", "--quality=0-90"]
-      lossy-highquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-100"]
+      lossy-lowquality: ["@_setup", "--speed=1", "--quality=0-60"]
+      lossy-subparquality: ["@_setup", "--speed=1", "--quality=0-70"]
+      lossy-midquality: ["@_setup", "--speed=1", "--quality=0-80"]
+      lossy-finequality: ["@_setup", "--speed=1", "--quality=0-90"]
+      lossy-highquality: ["@_setup", "--speed=1", "--quality=0-100"]
       # lossy-almostperfect omitted: Can't consistently reach 90 SSIM2 at max quality score
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
 
@@ -295,22 +312,23 @@ tools:
   # JPEG
   # JPEG does not support transparent pixels, no image-keepalpha
   jpegoptim:
-    description: Lossless and lossy JPEG optimizer. https://github.com/tjko/jpegoptim/
+    description: Lossless and lossy JPEG compressor. https://github.com/tjko/jpegoptim/
     command: jpegoptim
     platform: [windows, darwin, linux]
     supported-formats: [image/jpeg]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--force"]
-      lossless-loweffort: ["--force"]
-      lossless-higheffort: ["--force"]
-      lossless-maxbrute: ["--force"]
-      lossy-lowquality: ["--force", "-m25"]
-      lossy-subparquality: ["--force", "-m35"]
-      lossy-midquality: ["--force", "-m55"]
-      lossy-finequality: ["--force", "-m70"]
-      lossy-highquality: ["--force", "-m90"]
-      lossy-almostperfect: ["--force", "-m95"]
+      _setup: ["--force"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup"]
+      lossless-higheffort: ["@_setup"]
+      lossless-maxbrute: ["@_setup"]
+      lossy-lowquality: ["@_setup", "-m25"]
+      lossy-subparquality: ["@_setup", "-m35"]
+      lossy-midquality: ["@_setup", "-m55"]
+      lossy-finequality: ["@_setup", "-m70"]
+      lossy-highquality: ["@_setup", "-m90"]
+      lossy-almostperfect: ["@_setup", "-m95"]
 
   # https://github.com/mozilla/mozjpeg/
   # https://github.com/libjpeg-turbo/libjpeg-turbo
@@ -322,10 +340,11 @@ tools:
     supported-formats: [image/jpeg]
     output-mode: stdout
     arguments:
-      default-args: ["-optimize"]
-      lossless-loweffort: ["-optimize"]
-      lossless-higheffort: ["-optimize"]
-      lossless-maxbrute: ["-optimize"]
+      _setup: ["-optimize"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup"]
+      lossless-higheffort: ["@_setup"]
+      lossless-maxbrute: ["@_setup"]
       # lossy-* omitted: Lossless only
 
   guetzli:
@@ -354,16 +373,17 @@ tools:
     supported-formats: [image/gif]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--batch", "--threads", "-O2"]
-      lossless-loweffort: ["--batch", "--threads", "-O1"]
-      lossless-higheffort: ["--batch", "--threads", "-O3"]
-      lossless-maxbrute: ["--batch", "--threads", "-O3"]
+      _setup: ["--batch", "--threads"]
+      default-args: ["@_setup", "-O2"]
+      lossless-loweffort: ["@_setup", "-O1"]
+      lossless-higheffort: ["@_setup", "-O3"]
+      lossless-maxbrute: ["@_setup", "-O3"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels.
       # -Okeepempty exists but it only keeps fully empty transparent *frames*, not pixels
-      lossy-lowquality: ["--batch", "--threads", "-O3", "--lossy=80"]
-      lossy-subparquality: ["--batch", "--threads", "-O3", "--lossy=50"]
-      lossy-midquality: ["--batch", "--threads", "-O3", "--lossy=40"]
-      lossy-finequality: ["--batch", "--threads", "-O3", "--lossy=20"]
-      lossy-highquality: ["--batch", "--threads", "-O3", "--lossy=10"]
-      lossy-almostperfect: ["--batch", "--threads", "-O3", "--lossy=2"]
+      lossy-lowquality: ["@_setup", "-O3", "--lossy=80"]
+      lossy-subparquality: ["@_setup", "-O3", "--lossy=50"]
+      lossy-midquality: ["@_setup", "-O3", "--lossy=40"]
+      lossy-finequality: ["@_setup", "-O3", "--lossy=20"]
+      lossy-highquality: ["@_setup", "-O3", "--lossy=10"]
+      lossy-almostperfect: ["@_setup", "-O3", "--lossy=2"]
 

--- a/internal/compressor/compress.go
+++ b/internal/compressor/compress.go
@@ -353,9 +353,9 @@ func (c *CompressionProcess) IsErrorFree() (ok bool) {
 	return true
 }
 
-func ToolConfigToExecutedTool(tool *config.ToolConfig, argPreset string) (result ExecutedTool, ok bool) {
-	args, ok := tool.Arguments[argPreset]
-	if !ok {
+func ToolConfigToExecutedTool(tool *config.ToolConfig, argPreset string, toolName string) (result ExecutedTool, ok bool) {
+	args, err := tool.ResolveReferencesForPreset(argPreset, toolName)
+	if err != nil {
 		return ExecutedTool{}, false
 	}
 

--- a/internal/compressor/compress.go
+++ b/internal/compressor/compress.go
@@ -354,8 +354,8 @@ func (c *CompressionProcess) IsErrorFree() (ok bool) {
 }
 
 func ToolConfigToExecutedTool(tool *config.ToolConfig, argPreset string, toolName string) (result ExecutedTool, ok bool) {
-	args, err := tool.ResolveReferencesForPreset(argPreset, toolName)
-	if err != nil {
+	args, errs := tool.ResolveReferencesForPreset(argPreset, toolName)
+	if len(errs) > 0 {
 		return ExecutedTool{}, false
 	}
 

--- a/internal/compressor/compress.go
+++ b/internal/compressor/compress.go
@@ -354,7 +354,7 @@ func (c *CompressionProcess) IsErrorFree() (ok bool) {
 }
 
 func ToolConfigToExecutedTool(tool *config.ToolConfig, argPreset string, toolName string) (result ExecutedTool, ok bool) {
-	args, errs := tool.ResolveReferencesForPreset(argPreset, toolName)
+	args, errs := tool.ResolveIncludesForPreset(argPreset, toolName)
 	if len(errs) > 0 {
 		return ExecutedTool{}, false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,9 +229,9 @@ func (t *ToolConfig) ResolveReferencesForPreset(presetName, toolNameAs string) (
 }
 
 func (t *ToolConfig) resolveReferences(presetName, nameAs, previousPreset string, previousTrace []string) (result []string, errs []error) {
-	result = make([]string, 0)
-
 	arguments, ok := t.Arguments[presetName]
+	result = make([]string, 0, len(arguments))
+
 	if !ok {
 		return result, []error{fmt.Errorf("%q has preset reference that points to an unknown preset %q at: %s", nameAs, presetName, previousPreset)}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,6 +255,7 @@ func (t *ToolConfig) resolveReferences(presetName, nameAs, previousPreset string
 
 			result = append(result, innerArgs...)
 			errs = append(errs, innerErrors...)
+			continue
 		}
 
 		result = append(result, argument)

--- a/internal/config/defaultconfig.go
+++ b/internal/config/defaultconfig.go
@@ -33,6 +33,15 @@ presets:
       image/jpeg: [jpegoptim, ect, pingo]
       image/gif: [gifsicle]
 
+  _setup:
+    description: Internal preset meant to host arguments that are for setup. Not meant to be used directly.
+    shorthands: []
+    default-tools:
+      image/vnd.mozilla.apng: []
+      image/png: []
+      image/jpeg: []
+      image/gif: []
+
   lossless-loweffort:
     description: Lossless compression with fast, low effort compression settings.
     shorthands: [lossless-low, ll-low, lossless-fast, ll-fast]
@@ -56,7 +65,7 @@ presets:
     shorthands: []
     default-tools:
       image/vnd.mozilla.apng: [oxipng, pingo]
-      image/png: [oxipng, ect, pngout]
+      image/png: [oxipng, ect, pngout, pingo]
       image/jpeg: [jpegoptim, jpegtran, ect, pingo]
       image/gif: [gifsicle]
 
@@ -139,11 +148,12 @@ tools:
     supported-formats: [image/png, image/jpeg]
     output-mode: batch-overwrite
     arguments:
-      default-args: []
+      _setup: ["--mt-file", "--mt-deflate"]
+      default-args: ["@_setup"]
       # Note: --mt-deflate speeds up processing considerably, but produces in a very slightly larger image (~0.1-0.2% more)
-      lossless-loweffort: ["--mt-file", "--mt-deflate", "-2"] # ect does no compression at 1
-      lossless-higheffort: ["--mt-file", "--mt-deflate", "-9"]
-      lossless-maxbrute: ["--mt-file", "--mt-deflate", "-9", "--allfilters"]
+      lossless-loweffort: ["@default-args", "-2"] # ect does no compression at 1
+      lossless-higheffort: ["@default-args", "-9"]
+      lossless-maxbrute: ["@default-args", "-9", "--allfilters"]
       # Omitted, still modifies fully transparent pixels
       #image-keepalpha: ["--mt-file", "--mt-deflate", "-9", "--strict"]
       # lossy-* omitted: Lossless only
@@ -155,19 +165,20 @@ tools:
     supported-formats: [image/png, image/jpeg]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["mogrify", "-define", "png:compression-level=9", "-quality", "90"]
+      _setup: ["mogrify"]
+      default-args: ["@_setup", "-define", "png:compression-level=9", "-quality", "90"]
       # Lossless compression is PNG only
-      lossless-loweffort: ["mogrify", "-define", "png:compression-level=5", "-quality", "100"]
-      lossless-higheffort: ["mogrify", "-define", "png:compression-level=9", "-quality", "100"]
-      lossless-maxbrute: ["mogrify", "-define", "png:compression-level=9", "-quality", "100"]
+      lossless-loweffort: ["@_setup", "-define", "png:compression-level=5", "-quality", "100"]
+      lossless-higheffort: ["@_setup", "-define", "png:compression-level=9", "-quality", "100"]
+      lossless-maxbrute: ["@_setup", "-define", "png:compression-level=9", "-quality", "100"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # Lossy compression is JPEG only
-      lossy-lowquality: ["mogrify", "-quality", "25"]
-      lossy-subparquality: ["mogrify", "-quality", "35"]
-      lossy-midquality: ["mogrify", "-quality", "50"]
-      lossy-finequality: ["mogrify", "-quality", "70"]
-      lossy-highquality: ["mogrify", "-quality", "85"]
-      lossy-almostperfect: ["mogrify", "-quality", "100"]
+      lossy-lowquality: ["@_setup", "-quality", "25"]
+      lossy-subparquality: ["@_setup", "-quality", "35"]
+      lossy-midquality: ["@_setup", "-quality", "50"]
+      lossy-finequality: ["@_setup", "-quality", "70"]
+      lossy-highquality: ["@_setup", "-quality", "85"]
+      lossy-almostperfect: ["@_setup", "-quality", "100"]
 
   pingo:
     description: Lossless and lossy image compressor designed for web context. https://css-ig.net/pingo/
@@ -195,10 +206,11 @@ tools:
     supported-formats: [image/png, image/vnd.mozilla.apng]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--force"]
-      lossless-loweffort: ["--force", "-o", "1", "-a"]
-      lossless-higheffort: ["--force", "-o", "max", "-a"]
-      lossless-maxbrute: ["--force", "-o", "max", "-a", "-Z", "--zi", "100"]
+      _setup: ["--force"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup", "-o", "1", "-a"]
+      lossless-higheffort: ["@_setup", "-o", "max", "-a"]
+      lossless-maxbrute: ["@_setup", "-o", "max", "-a", "-Z", "--zi", "100"]
       # Omitted, still modifies fully transparent pixels
       #image-keepalpha: ["--force", "-o", "max"] # Opt-out of -a
       # lossy-* omitted: Lossless only
@@ -210,10 +222,11 @@ tools:
     supported-formats: [image/png]
     output-mode: input-output
     arguments:
-      default-args: ["-force", "-y"]
-      lossless-loweffort: ["-force", "-y", "-s3"]
-      lossless-higheffort: ["-force", "-y", "-s1"]
-      lossless-maxbrute: ["-force", "-y", "-s0"]
+      _setup: ["-force", "-y"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup", "-s3"]
+      lossless-higheffort: ["@_setup", "-s1"]
+      lossless-maxbrute: ["@_setup", "-s0"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
       # lossy-* omitted: Lossless only
 
@@ -238,13 +251,14 @@ tools:
     supported-formats: [image/png]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--ext=.png", "--force"]
+      _setup: ["--ext=.png", "--force"]
+      default-args: ["@_setup"]
       # lossless-* omitted: Lossy only
-      lossy-lowquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-60"]
-      lossy-subparquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-70"]
-      lossy-midquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-80"]
-      lossy-finequality: ["--ext=.png", "--force", "--speed=1", "--quality=0-90"]
-      lossy-highquality: ["--ext=.png", "--force", "--speed=1", "--quality=0-100"]
+      lossy-lowquality: ["@_setup", "--speed=1", "--quality=0-60"]
+      lossy-subparquality: ["@_setup", "--speed=1", "--quality=0-70"]
+      lossy-midquality: ["@_setup", "--speed=1", "--quality=0-80"]
+      lossy-finequality: ["@_setup", "--speed=1", "--quality=0-90"]
+      lossy-highquality: ["@_setup", "--speed=1", "--quality=0-100"]
       # lossy-almostperfect omitted: Can't consistently reach 90 SSIM2 at max quality score
       # image-keepalpha omitted: Does not support preserving fully transparent pixels
 
@@ -258,16 +272,17 @@ tools:
     supported-formats: [image/jpeg]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--force"]
-      lossless-loweffort: ["--force"]
-      lossless-higheffort: ["--force"]
-      lossless-maxbrute: ["--force"]
-      lossy-lowquality: ["--force", "-m25"]
-      lossy-subparquality: ["--force", "-m35"]
-      lossy-midquality: ["--force", "-m55"]
-      lossy-finequality: ["--force", "-m70"]
-      lossy-highquality: ["--force", "-m90"]
-      lossy-almostperfect: ["--force", "-m95"]
+      _setup: ["--force"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup"]
+      lossless-higheffort: ["@_setup"]
+      lossless-maxbrute: ["@_setup"]
+      lossy-lowquality: ["@_setup", "-m25"]
+      lossy-subparquality: ["@_setup", "-m35"]
+      lossy-midquality: ["@_setup", "-m55"]
+      lossy-finequality: ["@_setup", "-m70"]
+      lossy-highquality: ["@_setup", "-m90"]
+      lossy-almostperfect: ["@_setup", "-m95"]
 
   # https://github.com/mozilla/mozjpeg/
   # https://github.com/libjpeg-turbo/libjpeg-turbo
@@ -279,10 +294,11 @@ tools:
     supported-formats: [image/jpeg]
     output-mode: stdout
     arguments:
-      default-args: ["-optimize"]
-      lossless-loweffort: ["-optimize"]
-      lossless-higheffort: ["-optimize"]
-      lossless-maxbrute: ["-optimize"]
+      _setup: ["-optimize"]
+      default-args: ["@_setup"]
+      lossless-loweffort: ["@_setup"]
+      lossless-higheffort: ["@_setup"]
+      lossless-maxbrute: ["@_setup"]
       # lossy-* omitted: Lossless only
 
 
@@ -294,18 +310,19 @@ tools:
     supported-formats: [image/gif]
     output-mode: batch-overwrite
     arguments:
-      default-args: ["--batch", "--threads", "-O2"]
-      lossless-loweffort: ["--batch", "--threads", "-O1"]
-      lossless-higheffort: ["--batch", "--threads", "-O3"]
-      lossless-maxbrute: ["--batch", "--threads", "-O3"]
+      _setup: ["--batch", "--threads"]
+      default-args: ["@_setup", "-O2"]
+      lossless-loweffort: ["@_setup", "-O1"]
+      lossless-higheffort: ["@_setup", "-O3"]
+      lossless-maxbrute: ["@_setup", "-O3"]
       # image-keepalpha omitted: Does not support preserving fully transparent pixels.
       # -Okeepempty exists but it only keeps fully empty transparent *frames*, not pixels
-      lossy-lowquality: ["--batch", "--threads", "-O3", "--lossy=80"]
-      lossy-subparquality: ["--batch", "--threads", "-O3", "--lossy=50"]
-      lossy-midquality: ["--batch", "--threads", "-O3", "--lossy=40"]
-      lossy-finequality: ["--batch", "--threads", "-O3", "--lossy=20"]
-      lossy-highquality: ["--batch", "--threads", "-O3", "--lossy=10"]
-      lossy-almostperfect: ["--batch", "--threads", "-O3", "--lossy=2"]
+      lossy-lowquality: ["@_setup", "-O3", "--lossy=80"]
+      lossy-subparquality: ["@_setup", "-O3", "--lossy=50"]
+      lossy-midquality: ["@_setup", "-O3", "--lossy=40"]
+      lossy-finequality: ["@_setup", "-O3", "--lossy=20"]
+      lossy-highquality: ["@_setup", "-O3", "--lossy=10"]
+      lossy-almostperfect: ["@_setup", "-O3", "--lossy=2"]
 
 `
 }


### PR DESCRIPTION
### TL;DR:

You can now include arguments from other presests in the same tool in your configuration to reduce duplication. The syntax is `@preset-name` For example:
```yaml
pngout:
    description: Lossless PNG compressor. http://www.advsys.net/ken/utils.html
    command: pngout
    platform: [windows, darwin, linux]
    supported-formats: [image/png]
    output-mode: input-output
    arguments:
      default-args: ["-force", "-y"]
      lossless-loweffort: ["@default-args", "-s3"]
      lossless-higheffort: ["@default-args", "-s1"]
      lossless-maxbrute: ["@default-args", "-s0"]
      ...
  ```
  
 ##  The (slightly) longer read:
 *Preset Includes* allows you to include arguments from other presets (at the same tool) in a preset. To use it, in a preset at the tool's `arguments:` list, use the syntax `@preset-name` where `preset-name` is a name of another preset. compacty will then include that preset's arguments to the original preset. Using the above example, `lossless-loweffort`'s arguments become `["-force", "-y", "-s3"]`. You can have multiple includes at once, or chained includes if needed. For example:
 
 ```yaml
 arguments:
      one: ["--one"]
      two: ["--two"]
      multiple: ["@one", "@two"]  # becomes ["--one", "--two"]
      chained: ["@multiple", "--three"]  # becomes ["--one", "--two", "--three"]
```

 Note that circular includes and includes pointing to an undefined preset are not allowed. For example, these will cause an error:
  ```yaml
 arguments:
      a: ["@b"]
      b: ["@a"]
      self-include: ["@self-include"]
      nothing: ["@literally-nothing"]
```
I wanted to have this feature because it helps in deduplicating argument that are there for boilerplate setup (forcing overwrite mode for example). 
 
This PR implements Preset Includes, testing, documentation, and changes the default config and the complete config to make use of preset includes
 
 Originally I called this feature *Argument References* but I feel like *Preset Includes* is more fitting